### PR TITLE
Added publication status as option

### DIFF
--- a/notify_entity.module
+++ b/notify_entity.module
@@ -38,6 +38,15 @@ function _notify_entity_trigger_event($event, Drupal\Core\Entity\EntityInterface
 
   if ($value = $config->get($key)) {
     if ($value[$event]) {
+      // If status is set, check if it matches condition
+      if (isset($value['status']) && $value['status'] != 'any') {
+        if (
+        ($entity->isPublished() && $value['status'] == 'unpublished') ||
+        (!$entity->isPublished() && $value['status'] == 'published')
+        ) {
+          return;
+        }
+      }
       $module = 'notify_entity';
       $key = 'new_post';
       $to = $value['email'];

--- a/src/Form/NotifyEntityForm.php
+++ b/src/Form/NotifyEntityForm.php
@@ -73,8 +73,8 @@ class NotifyEntityForm extends ConfigFormBase {
       'insert' => TRUE,
       'update' => FALSE,
       'delete' => FALSE,
+      'status' => 'any'
     ];
-
     return [
       '#type' => 'details',
       '#title' => $title,
@@ -98,6 +98,17 @@ class NotifyEntityForm extends ConfigFormBase {
         '#type' => 'checkbox',
         '#title' => $this->t('Trigger on delete'),
         '#default_value' => $defaults['delete'],
+      ],
+      'status' => [
+        '#type' => 'radios',
+        '#title' => $this->t('State'),
+        '#options' => [
+          'any' => $this->t('Any'),
+          'published' => $this->t('Published'),
+          'unpublished' => $this->t('Unpublished'),
+        ],
+        '#access' => ($entity_type == 'node' || $entity_type == 'comment'),
+        '#default_value' => $defaults['status'],
       ],
     ];
   }


### PR DESCRIPTION
I need a webmaster to be able to receive notification of draft content (handled by Workbench Moderation) but not to receive notifications about new content from other colleagues. For this reason, I added in the posibility to specify a publication state (published / unpublished) condition for comment and node entity types.
